### PR TITLE
Add a trigger for new intake records

### DIFF
--- a/functions/airtableTriager.js
+++ b/functions/airtableTriager.js
@@ -1,16 +1,82 @@
 const functions = require('firebase-functions');
 
-const { getChangedIntakeTickets } = require('./airtable');
+const Slack = require("slack")
+
+const { getChangedIntakeTickets } = require("./airtable")
+
+const bot = new Slack({ "token": functions.config().slack.token })
+
+const NEIGHBORHOOD_TO_CHANNEL = {
+    "NW": "northwest_bedstuy",
+    "NE": "northeast_bedstuy",
+    "SW": "southwest_bedstuy",
+    "SE": "southeast_bedstuy",
+    // "Clinton Hill / Fort Greene": "clintonhill",
+    // "Crown Heights / Brownsville / Flatbush": "crownheights",
+}
+
+const CHANNEL_TO_ID = functions.config().slack.channel_to_id;
+
+async function onNewIntake(id, fields) {
+    console.log(`onNewIntake(${id})`)
+
+    const neighborhoodChanName = NEIGHBORHOOD_TO_CHANNEL[fields["Neighborhood"]]
+
+    // e.g. crown heights
+    if (!neighborhoodChanName) {
+        return
+    }
+
+    const neighborhoodChanID = CHANNEL_TO_ID[neighborhoodChanName]
+
+    // TODO : add some better content
+    const res = await bot.chat.postMessage({
+        "channel": neighborhoodChanID,
+        "text": `HELLO! There is a new ticket: ${fields["Ticket ID"]}`,
+    })
+
+    if (!res["ok"]) {
+        console.error(`Encountered an error posting ticket to #${neighborhoodChanName}: ${id}`)
+        return
+    }
+}
 
 // Runs every minute
 exports.poll.airtableIntakeTickets = functions.pubsub.schedule('* * * * *').onRun(async () => {
+    const STATUS_TO_CBS = {
+        "Seeking Volunteer": [onNewIntake],
+        "Assigned / In Progress": [],
+        "Complete": [],
+        "Not Bed-Stuy": [],
+    }
+
     const changedTickets = await getChangedIntakeTickets()
 
     if (changedTickets.length === 0) {
         return null
     }
 
-    console.log(changedTickets)
+    // TODO : it is possible for us to miss a step in the intake ticket state transitions.
+    // A ticket should go from "Seeking Volunteer" -> "Assigned" -> "Complete". Since we
+    // only trigger on the current state, there is a race condition where we could miss
+    // the intermediate state (i.e. assigned)
+    for (const [id, fields] of changedTickets) {
+        console.log(`Processing intake ticket (${fields["Ticket ID"]}): ${id}`)
+
+        const status = fields["Status"]
+        if (!(status in STATUS_TO_CBS)) {
+            console.error(`Ticket has invalid status: ${status}`)
+            continue
+        }
+
+        for (const cb of STATUS_TO_CBS[status]) {
+            // eslint-disable-next-line callback-return
+            await cb(id, fields)
+        }
+    }
+
+    // TODO : disable this logging later, might be useful as we get this up and running
+    console.log(`All changed tickets: ${changedTickets}`)
 
     return null
 })

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -3232,6 +3232,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "slack": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/slack/-/slack-11.0.2.tgz",
+      "integrity": "sha512-rv842+S+AGyZCmMMd8xPtW5DvJ9LzWTAKfxi8Gw57oYlXgcKtFuHd4nqk6lTPpRKdUGn3tx/Drd0rjQR3dQPqw==",
+      "requires": {
+        "tiny-json-http": "^7.0.2"
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -3444,6 +3452,11 @@
       "requires": {
         "readable-stream": "2 || 3"
       }
+    },
+    "tiny-json-http": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.1.2.tgz",
+      "integrity": "sha512-XB9Bu+ohdQso6ziPFNVqK+pcTt0l8BSRkW/CCBq0pUVlLxcYDsorpo7ae5yPhu2CF1xYgJuKVLF7cfOGeLCTlA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,6 +18,7 @@
     "firebase-admin": "^8.6.0",
     "firebase-functions": "^3.3.0",
     "libphonenumber-js": "^1.7.48",
+    "slack": "^11.0.2",
     "twilio": "^3.41.1"
   },
   "devDependencies": {

--- a/functions/test/index.test.js
+++ b/functions/test/index.test.js
@@ -1,8 +1,9 @@
-const assert = require("assert")
 const test = require('firebase-functions-test')()
 
+const assert = require("assert")
 const mocha = require("mocha")
 
+const GARAGE_CHAN_ID = "C0106GP18UT"
 test.mockConfig(
     {
         "airtable": {
@@ -11,12 +12,22 @@ test.mockConfig(
             "base_id": "<REPLACE>",
             "intake_messages_table": "_test_sms_intake_messages",
             "inbound_table": "_test_inbound",
-            "intake_table": "_test_intake"
+            "intake_table": "_test_intake",
+        },
+        "slack": {
+            "token": "<REPLACE>",
+            "northeast_bedstuy": GARAGE_CHAN,
+            "northwest_bedstuy": GARAGE_CHAN,
+            "southeast_bedstuy": GARAGE_CHAN,
+            "southwest_bedstuy": GARAGE_CHAN,
         },
     }
 )
 
+const Slack = require("slack")
 const { getAllIntakeTickets, getChangedIntakeTickets } = require("../airtable")
+
+const bot = new Slack({ "token": "<REPLACE>" })
 
 
 describe("test get all intake tickets", () => {
@@ -30,5 +41,25 @@ describe("test get all new tickets", () => {
     it("basic", async () => {
         const tickets = await getChangedIntakeTickets()
         console.log(tickets.length)
+    })
+})
+
+describe("test slack", () => {
+    it("list channels", async () => {
+        const res = await bot.channels.list()
+        const channels = res.channels
+
+        for (const chan of channels) {
+            if (chan.name === "garage") {
+                return
+            }
+        }
+    })
+
+    it("send test message", async () => {
+        const res = await bot.chat.postMessage({
+            "channel": GARAGE_CHAN_ID,
+            "text": "HELLO!",
+        })
     })
 })


### PR DESCRIPTION
The trigger mechanism calls relevant callbacks everytime a ticket status changes. The intake trigger will post a message to the neighborhood channel every time a new ticket is created.