### PR TITLE
Reassign delivery volunteer

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
     "serve": "npx firebase emulators:start --only functions",
     "shell": "npx firebase functions:shell",
     "start": "npm run shell",
-    "test": "mocha --reporter spec"
+    "test": "mocha --timeout 100000 --reporter spec"
   },
   "engines": {
     "node": "8"

--- a/functions/test/index.test.js
+++ b/functions/test/index.test.js
@@ -1,9 +1,10 @@
-const test = require('firebase-functions-test')()
+const functions = require('firebase-functions');
+const test = require('firebase-functions-test')();
 
-const assert = require("assert")
-const mocha = require("mocha")
+const assert = require("assert");
+const mocha = require("mocha");
 
-const GARAGE_CHAN_ID = "C0106GP18UT"
+const GARAGE_CHAN_ID = "C0106GP18UT";
 test.mockConfig(
     {
         "airtable": {
@@ -22,45 +23,48 @@ test.mockConfig(
             "southwest_bedstuy": GARAGE_CHAN_ID,
             "delivery_volunteers": GARAGE_CHAN_ID,
         },
+        "environment": {
+            "type": "test"
+        }
     }
-)
+);
 
-const Slack = require("slack")
-const { getAllIntakeTickets, getChangedIntakeTickets } = require("../airtable")
+const Slack = require("slack");
+const { getAllRecords, getChangedRecords, INTAKE_TABLE } = require("../airtable");
 
-const bot = new Slack({ "token": "<REPLACE>" })
+const bot = new Slack({ "token": functions.config().slack.token });
 
 
-describe("test get all intake tickets", () => {
+describe("test get all intake records", () => {
     it("basic", async () => {
-        const tickets = await getAllIntakeTickets()
-        assert(tickets.length > 0)
-    })
-})
+        const tickets = await getAllRecords(INTAKE_TABLE);
+        assert(tickets.length > 0);
+    });
+});
 
-describe("test get all new tickets", () => {
+describe("test get all new intake tickets", () => {
     it("basic", async () => {
-        const tickets = await getChangedIntakeTickets()
-        console.log(tickets.length)
-    })
-})
+        const tickets = await getChangedRecords(INTAKE_TABLE);
+        console.log(tickets.length);
+    });
+});
 
 describe("test slack", () => {
     it("list channels", async () => {
-        const res = await bot.channels.list()
-        const channels = res.channels
+        const res = await bot.channels.list();
+        const channels = res.channels;
 
         for (const chan of channels) {
             if (chan.name === "garage") {
-                return
+                return;
             }
         }
-    })
+    });
 
     it("send test message", async () => {
         const res = await bot.chat.postMessage({
             "channel": GARAGE_CHAN_ID,
             "text": "HELLO!",
-        })
-    })
-})
+        });
+    });
+});


### PR DESCRIPTION
- Adds a `lastSeenDeliveryVolunteer` field to `_meta`
- Allows polling functions to specify non-status fields to watch when considering which tickets have changed
- Intakes table will check for changes to deliveryVolunteer
- (also fixes the test file to work again)

I don't love how much complexity this approach adds to the code. Now `onIntakeX` functions have to check whether or not they're being called because of a status change or because of some other change.

Needs to be tested