### PR TITLE
Allow callback urls for other tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,4 @@ exports.test = functions.https.onRequest(async (_req, res) => {
 
 ## inbound functions
 
-twilio is weird and makes voicemails into something that requires 3 separate requests https://www.twilio.com/docs/voice/twiml/record (we can replace at least 1 with a static url)
-
 https://firebase.google.com/docs/functions/http-events#use_middleware_modules_with

--- a/functions/inbound.js
+++ b/functions/inbound.js
@@ -97,7 +97,7 @@ module.exports = {
 
     await requestConnectCall(volunteerPhoneNumber, recordPhoneNumber);
 
-    res.status(200).send(`Hi ${volunteerFields.name}! You'll get a call from Bed-Stuy Strong shortly connecting you to ${recordPhoneNumber}`);
+    res.status(200).send(`You'll get a call at ${volunteerFields.phoneNumber} from Bed-Stuy Strong shortly connecting you to ${recordFields.phoneNumber}`);
   }),
 
 };

--- a/functions/schema.js
+++ b/functions/schema.js
@@ -25,6 +25,7 @@ const INTAKE_SCHEMA = {
   status: STATUS,
   intakeVolunteer: 'Intake Volunteer - This is you!',
   deliveryVolunteer: 'Delivery Volunteer',
+  bulkCallbackVolunteer: 'Bulk Callback Volunteer',
   neighborhood: 'Neighborhood',
   requestName: 'Requestor First Name and Last Initial',
   timeline: 'Need immediacy',
@@ -65,6 +66,7 @@ const REIMBURSEMENT_SCHEMA = {
 
 const VOLUNTEER_SCHEMA = {
   status: STATUS,
+  name: 'Name',
   email: 'Email Address',
   slackUserID: 'Slack User ID',
   slackEmail: 'Email Address (from Slack)',

--- a/functions/schema.js
+++ b/functions/schema.js
@@ -25,7 +25,6 @@ const INTAKE_SCHEMA = {
   status: STATUS,
   intakeVolunteer: 'Intake Volunteer - This is you!',
   deliveryVolunteer: 'Delivery Volunteer',
-  bulkCallbackVolunteer: 'Bulk Callback Volunteer',
   neighborhood: 'Neighborhood',
   requestName: 'Requestor First Name and Last Initial',
   timeline: 'Need immediacy',
@@ -66,7 +65,6 @@ const REIMBURSEMENT_SCHEMA = {
 
 const VOLUNTEER_SCHEMA = {
   status: STATUS,
-  name: 'Name',
   email: 'Email Address',
   slackUserID: 'Slack User ID',
   slackEmail: 'Email Address (from Slack)',


### PR DESCRIPTION
now takes 3 url params:
- `table`: `inbound` or `intake` (would rather not pass the table name directly for security)
- `record`: Airtable record ID, can access in a formula using `RECORD_ID()`
- `volunteer`: Volunteer record ID, can be accessed in a formula by adding a Lookup field that references the linked volunteer record and gets the field called `Record ID`

the formula for the bulk callback link ends up looking something like 
```
CONCATENATE("[URL_HERE]/inbound-callback?table=intake&record=", RECORD_ID(), "&volunteer=", {Bulk Callback Volunteer ID})
```