### PR TITLE
Add vax support twilio number to outbound calls

### DIFF
--- a/functions/airtable.js
+++ b/functions/airtable.js
@@ -686,6 +686,7 @@ module.exports = {
   META_TABLE: META_TABLE,
   REIMBURSEMENTS_TABLE: REIMBURSEMENTS_TABLE,
   VOLUNTEER_FORM_TABLE: VOLUNTEER_FORM_TABLE,
+  VAX_SUPPORT_TABLE: VAX_SUPPORT_TABLE,
   createMessage: createMessage,
   createRecord: createRecord,
   createVoicemail: createVoicemail,

--- a/functions/inbound.js
+++ b/functions/inbound.js
@@ -140,7 +140,7 @@ module.exports = {
       return;
     }
 
-    if (baseId !== 'vaxSupport') {
+    if (baseId !== functions.config().airtable.vax_support_base_id) {
       res.status(500).send('Incorrect callback base');
       return;
     }

--- a/functions/inbound.js
+++ b/functions/inbound.js
@@ -129,13 +129,18 @@ module.exports = {
     res.status(200).send(`You'll get a call at ${volunteerFields.phoneNumber} from Bed-Stuy Strong shortly connecting you to ${recordFields.phoneNumber}`);
   }),
 
-  // NOTE that this endpoint is currently being used for vax support callbacks
-  callback_basic: functions.https.onRequest(async (req, res) => {
+  vaxSupportCallback: functions.https.onRequest(async (req, res) => {
     const volunteerPhoneNumberRaw = req.query.volunteerPhoneNumber;
     const neighborPhoneNumberRaw = req.query.neighborPhoneNumber;
+    const baseId = req.query.baseId;
 
-    if (!(volunteerPhoneNumberRaw && neighborPhoneNumberRaw)) {
+    if (!(volunteerPhoneNumberRaw && neighborPhoneNumberRaw && baseId)) {
       res.status(400).send('Missing required query params');
+      return;
+    }
+
+    if (baseId !== 'vaxSupport') {
+      res.status(500).send('Incorrect callback base');
       return;
     }
 

--- a/functions/inbound.js
+++ b/functions/inbound.js
@@ -9,6 +9,7 @@ const {
   createVoicemailRecordingPrompt,
   requestConnectCall,
   middlewareByProject,
+  vaxSupportRequestConnectCall,
 } = require('./twilio');
 const {
   createMessage,
@@ -73,7 +74,7 @@ module.exports = {
     const token = functions.config().twilio.vax_support.auth_token;
     return middlewareByProject(token, req, res, async () => {
       const fromNumber = parsePhoneNumberFromString(req.body.From).formatNational();
-      const recordingUrl = `${req.body.RecordingUrl}.mp3`;
+      const recordingUrl = req.body.RecordingUrl ? `${req.body.RecordingUrl}.mp3` : '';
 
       await createVaxSupportVoicemail(fromNumber, recordingUrl, '');
 
@@ -156,7 +157,7 @@ module.exports = {
       return;
     }
 
-    await requestConnectCall(volunteerPhoneNumber, neighborPhoneNumber, 'VAX_SUPPORT');
+    await vaxSupportRequestConnectCall(volunteerPhoneNumber, neighborPhoneNumber);
 
     res.status(200).send(`You'll get a call at ${volunteerPhoneNumber} from Bed-Stuy Strong shortly connecting you to ${neighborPhoneNumber}`);
   }),

--- a/functions/twilio.js
+++ b/functions/twilio.js
@@ -127,7 +127,7 @@ module.exports = {
   },
 
   requestConnectCall: (phoneNumber, connectNumber, table) => {
-    const outbound = table === 'VAX_SUPPORT' ? functions.config.twilio.vax_support.outbound_number : functions.config().twilio.outbound_number;
+    const outbound = table === 'VAX_SUPPORT' ? functions.config().twilio.vax_support.outbound_number : functions.config().twilio.outbound_number;
     const twiml = new VoiceResponse();
 
     twiml.dial(connectNumber);

--- a/functions/twilio.js
+++ b/functions/twilio.js
@@ -6,6 +6,9 @@ const { MessagingResponse, VoiceResponse } = twilio.twiml;
 
 const client = twilio(functions.config().twilio.sid, functions.config().twilio.auth_token);
 
+// vax support account has different number/auth
+const vaxSupportClient = twilio(functions.config().twilio.vax_support.sid, functions.config().twilio.vax_support.auth_token);
+
 module.exports = {
 
   /**
@@ -126,15 +129,26 @@ module.exports = {
     return twiml.toString();
   },
 
-  requestConnectCall: (phoneNumber, connectNumber, table) => {
-    const outbound = table === 'VAX_SUPPORT' ? functions.config().twilio.vax_support.outbound_number : functions.config().twilio.outbound_number;
+  requestConnectCall: (phoneNumber, connectNumber) => {
     const twiml = new VoiceResponse();
 
     twiml.dial(connectNumber);
 
     return client.calls.create({
       to: phoneNumber,
-      from: outbound,
+      from: functions.config().twilio.outbound_number,
+      twiml: twiml.toString(),
+    });
+  },
+
+  vaxSupportRequestConnectCall: (phoneNumber, connectNumber) => {
+    const twiml = new VoiceResponse();
+
+    twiml.dial(connectNumber);
+
+    return vaxSupportClient.calls.create({
+      to: phoneNumber,
+      from: functions.config().twilio.vax_support.outbound_number,
       twiml: twiml.toString(),
     });
   },

--- a/functions/twilio.js
+++ b/functions/twilio.js
@@ -126,14 +126,15 @@ module.exports = {
     return twiml.toString();
   },
 
-  requestConnectCall: (phoneNumber, connectNumber) => {
+  requestConnectCall: (phoneNumber, connectNumber, table) => {
+    const outbound = table === 'VAX_SUPPORT' ? functions.config.twilio.vax_support.outbound_number : functions.config().twilio.outbound_number;
     const twiml = new VoiceResponse();
 
     twiml.dial(connectNumber);
 
     return client.calls.create({
       to: phoneNumber,
-      from: functions.config().twilio.outbound_number,
+      from: outbound,
       twiml: twiml.toString(),
     });
   },


### PR DESCRIPTION
- Bring in the uncommitted vax support callback function
- Set the vax support-specific outbound number for callbacks so people can look for it on their caller ID